### PR TITLE
fix(sites/gitea): replace parent directory link icon

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,4 @@ export const icons = {
 };
 
 export const ATTRIBUTE_PREFIX = 'data-catppuccin-file-explorer-icons';
+export const CSS_SELECTOR_SELF = Symbol('__self__');

--- a/src/entries/content/lib.ts
+++ b/src/entries/content/lib.ts
@@ -5,7 +5,7 @@ import { flavor, monochrome, specificFolders } from '@/storage';
 
 import { flavors } from '@catppuccin/palette';
 
-import { ATTRIBUTE_PREFIX } from '@/constants';
+import { ATTRIBUTE_PREFIX, CSS_SELECTOR_SELF } from '@/constants';
 import icons from '@/icons.json';
 import type { ReplacementSelectorSet } from '@/sites';
 
@@ -109,7 +109,12 @@ export async function replaceIconInRow(
 	// Icon already has extension prefix, not necessary to replace again.
 	if (!iconEl || iconEl?.hasAttribute(ATTRIBUTE_PREFIX)) return;
 
-	const fileNameEl = rowEl.querySelector(selectors.filename) as HTMLElement;
+	const fileNameEl =
+		selectors.filename === CSS_SELECTOR_SELF
+			? rowEl
+			: (rowEl.querySelector(
+					selectors.filename as string,
+				) as HTMLElement);
 	if (!fileNameEl) return;
 	const fileName = fileNameEl.textContent
 		?.split('/')

--- a/src/sites/gitea.ts
+++ b/src/sites/gitea.ts
@@ -1,5 +1,5 @@
 import type { ReplacementSelectorSet, Site } from '.';
-import { ATTRIBUTE_PREFIX } from '../constants';
+import { ATTRIBUTE_PREFIX, CSS_SELECTOR_SELF } from '../constants';
 
 const mainRepositoryImplementation: ReplacementSelectorSet = {
 	row: '#repo-files-table .repo-file-item',
@@ -9,6 +9,15 @@ const mainRepositoryImplementation: ReplacementSelectorSet = {
 		iconEl.classList.contains('octicon-file-directory-fill'),
 	isSubmodule: (_rowEl, _fileNameEl, iconEl) =>
 		iconEl.classList.contains('octicon-file-submodule'),
+	isCollapsable: (_rowEl, _fileNameEl, _iconEl) => false,
+};
+
+const mainRepositoryParentLinkImplementation: ReplacementSelectorSet = {
+	row: '#repo-files-table .repo-file-line.parent-link',
+	filename: CSS_SELECTOR_SELF,
+	icon: '.svg',
+	isDirectory: (_rowEl, _fileNameEl, _iconEl) => true,
+	isSubmodule: (_rowEl, _fileNameEl, _iconEl) => false,
 	isCollapsable: (_rowEl, _fileNameEl, _iconEl) => false,
 };
 
@@ -65,6 +74,7 @@ export const gitea: Site = {
 	domains: ['gitea.com'],
 	replacements: [
 		mainRepositoryImplementation,
+		mainRepositoryParentLinkImplementation,
 		repositorySideTreeImplementation,
 		diffTreeImplementation,
 	],

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -13,7 +13,7 @@ export type FnWithContext<T> = (
 
 export type ReplacementSelectorSet = {
 	row: string;
-	filename: string;
+	filename: string | symbol;
 	icon: string;
 	isDirectory: FnWithContext<boolean>;
 	isSubmodule: FnWithContext<boolean>;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![CleanShot 2025-04-19 at 22 45 01](https://github.com/user-attachments/assets/de63b5eb-dd21-4c17-8a7b-07700854f933) | ![CleanShot 2025-04-19 at 22 44 50](https://github.com/user-attachments/assets/5fee000d-0494-4a0a-9424-8dfa95d2177f) |