### PR TITLE
fix: use basename of directory paths for icon filename

### DIFF
--- a/src/entries/content/lib.ts
+++ b/src/entries/content/lib.ts
@@ -118,7 +118,7 @@ export async function replaceIconInRow(
 	if (!fileNameEl) return;
 	const fileName = fileNameEl.textContent
 		?.split('/')
-		.at(0)
+		.at(-1)
 		.trim()
 		/* Remove [Unicode LEFT-TO-RIGHT MARK](https://en.wikipedia.org/wiki/Left-to-right_mark) used on GitLab's merge request diff file tree. */
 		.replace(/\u200E/g, '');


### PR DESCRIPTION
Gitlab includes the full repo-relative path to files in the header of the file contents in the commit diff view, with the previous behavior `docs/screenshots/foo.png` the filename would be recognized as `docs` instead of `foo.png`. In this case since we also knew it was a file not a directory, the icon would be blank/default since there is no `docs` file icon - only a directory icon - and the `png` icon isn't used because we extract the first not the last part of the path. This behavior is now fixed.

GitHub pull requests file tree sometimes collapses nested directories into a single filename, e.g. `tests/foo`, this would previously use the `tests` folder icon whereas it now uses the `foo` icon (if any).