### PR TITLE
feat(sites): release asset/artifact icons

### DIFF
--- a/src/entries/content/lib.ts
+++ b/src/entries/content/lib.ts
@@ -116,12 +116,15 @@ export async function replaceIconInRow(
 					selectors.filename as string,
 				) as HTMLElement);
 	if (!fileNameEl) return;
-	const fileName = fileNameEl.textContent
-		?.split('/')
-		.at(-1)
-		.trim()
-		/* Remove [Unicode LEFT-TO-RIGHT MARK](https://en.wikipedia.org/wiki/Left-to-right_mark) used on GitLab's merge request diff file tree. */
-		.replace(/\u200E/g, '');
+	const fileName =
+		'getFilename' in selectors
+			? selectors.getFilename(rowEl, fileNameEl, iconEl)
+			: fileNameEl.textContent
+					?.split('/')
+					.at(-1)
+					.trim()
+					/* Remove [Unicode LEFT-TO-RIGHT MARK](https://en.wikipedia.org/wiki/Left-to-right_mark) used on GitLab's merge request diff file tree. */
+					.replace(/\u200E/g, '');
 
 	const fileExtensions: Array<string> = [];
 	// Avoid doing an explosive combination of extensions for very long filenames

--- a/src/sites/forgejo.ts
+++ b/src/sites/forgejo.ts
@@ -37,7 +37,22 @@ ${diffTreeImplementation.row} {
 }
 `.trim();
 
+const releaseAssetsImplementation: ReplacementSelectorSet = {
+	row: '#release-list .download li',
+	filename: 'a',
+	icon: 'a > svg',
+	isDirectory: (_rowEl, _fileNameEl, _iconEl) => false,
+	isSubmodule: (_rowEl, _fileNameEl, _iconEl) => false,
+	isCollapsable: (_rowEl, _fileNameEl, _iconEl) => false,
+	getFilename: (_rowEl, fileNameEl, _iconEl) =>
+		(fileNameEl as HTMLAnchorElement).href,
+};
+
 export const forgejo: Site = {
 	domains: ['codeberg.org'],
-	replacements: [mainRepositoryImplementation, diffTreeImplementation],
+	replacements: [
+		mainRepositoryImplementation,
+		diffTreeImplementation,
+		releaseAssetsImplementation,
+	],
 };

--- a/src/sites/gitea.ts
+++ b/src/sites/gitea.ts
@@ -70,6 +70,17 @@ ${diffTreeImplementation.row} {
 }
 `.trim();
 
+const releaseAssetsImplementation: ReplacementSelectorSet = {
+	row: '#release-list .download li',
+	filename: 'a',
+	icon: 'a svg',
+	isDirectory: (_rowEl, _fileNameEl, _iconEl) => false,
+	isSubmodule: (_rowEl, _fileNameEl, _iconEl) => false,
+	isCollapsable: (_rowEl, _fileNameEl, _iconEl) => false,
+	getFilename: (_rowEl, fileNameEl, _iconEl) =>
+		(fileNameEl as HTMLAnchorElement).href,
+};
+
 export const gitea: Site = {
 	domains: ['gitea.com'],
 	replacements: [
@@ -77,5 +88,6 @@ export const gitea: Site = {
 		mainRepositoryParentLinkImplementation,
 		repositorySideTreeImplementation,
 		diffTreeImplementation,
+		releaseAssetsImplementation,
 	],
 };

--- a/src/sites/github.ts
+++ b/src/sites/github.ts
@@ -76,6 +76,24 @@ ${pullRequestTreeImplementation.row} {
 }
 	`.trim();
 
+const releaseAssetsImplementation: ReplacementSelectorSet = {
+	row: '#release_page_title + div > section ul li',
+	filename: 'a.Truncate',
+	icon: 'svg.octicon',
+	isDirectory: (_rowEl, _fileNameEl, _iconEl) => false,
+	isSubmodule: (_rowEl, _fileNameEl, _iconEl) => false,
+	isCollapsable: (_rowEl, _fileNameEl, _iconEl) => false,
+	getFilename: (_rowEl, fileNameEl, _iconEl) =>
+		(fileNameEl as HTMLAnchorElement).href,
+};
+releaseAssetsImplementation.styles = /* css */ `
+${releaseAssetsImplementation.row} {
+	svg[${ATTRIBUTE_PREFIX}] {
+		margin-right: 4px;
+	}
+}
+	`.trim();
+
 export const github: Site = {
 	domains: ['github.com'],
 	replacements: [
@@ -83,5 +101,6 @@ export const github: Site = {
 		repositoryMainImplementation,
 		pullRequestTreeImplementation,
 		repositoryMainParentDirectoryImplementation,
+		releaseAssetsImplementation,
 	],
 };

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -18,6 +18,7 @@ export type ReplacementSelectorSet = {
 	isDirectory: FnWithContext<boolean>;
 	isSubmodule: FnWithContext<boolean>;
 	isCollapsable: FnWithContext<boolean>;
+	getFilename?: FnWithContext<string>;
 	styles?: string;
 };
 


### PR DESCRIPTION
Closes #203. Themes release asset/artifacts on GitHub, Forgejo, and Gitea.